### PR TITLE
Add notes on Oauth2 application type

### DIFF
--- a/bingads_downloader/downloader.py
+++ b/bingads_downloader/downloader.py
@@ -212,8 +212,8 @@ def authenticate_with_oauth(api_client):
     except OAuthTokenRequestException as exc:
         print('Authentication error. Could be necessary to run refresh refresh-bingads-api-oauth2-token', file=sys.stderr)
         print('Ensure that the registered application type is Native-Application', file=sys.stderr)
-        print(f' - client id: {config.oauth2_client_id()}', file=sys.stderr)
-        print(f' - refresh_token: {refresh_token}', file=sys.stderr)
+        print(' - client id: {}'.format(config.oauth2_client_id()), file=sys.stderr)
+        print(' - refresh_token: {}'.format(refresh_token), file=sys.stderr)
         print(exc, file=sys.stderr)
         sys.exit(1)
 

--- a/bingads_downloader/downloader.py
+++ b/bingads_downloader/downloader.py
@@ -210,8 +210,11 @@ def authenticate_with_oauth(api_client):
             print('No refresh token found. Please run refresh refresh-bingads-api-oauth2-token')
             sys.exit(1)
     except OAuthTokenRequestException as exc:
-        print('Authentication error. Could be necessary to run refresh refresh-bingads-api-oauth2-token')
-        print(exc)
+        print('Authentication error. Could be necessary to run refresh refresh-bingads-api-oauth2-token', file=sys.stderr)
+        print('Ensure that the registered application type is Native-Application', file=sys.stderr)
+        print(f' - client id: {config.oauth2_client_id()}', file=sys.stderr)
+        print(f' - refresh_token: {refresh_token}', file=sys.stderr)
+        print(exc, file=sys.stderr)
         sys.exit(1)
 
 

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,6 @@ setup(
             'download-bingsads-performance-data=bingads_downloader.cli:download_data',
             'refresh-bingsads-api-oauth2-token=bingads_downloader.cli:refresh_oauth2_token'
         ]
-    }
+    },
+    python_requires='>=3.3'
 )


### PR DESCRIPTION
We found a problem with the application type that wasn't hinted in error message, fixed.
Also better formatting and using stderr.