### PR TITLE
Download timeout retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,29 +116,39 @@ For all options, see
       config.py are used.
 
     Options:
-      --developer_token TEXT       The developer token that is used to access the
-                                   BingAds API. Default: "012345679ABCDEF"
-      --oauth2_client_id TEXT      The Oauth client id obtained from the BingAds
-                                   developer center. Default:
-                                   "abc1234-1234-1234-abc-abcd1234"
-      --oauth2_client_secret TEXT  The Oauth client secret obtained from the
-                                   BingAds developer center. Default:
-                                   "ABCDefgh!1234567890"
-      --oauth2_refresh_token TEXT  The Oauth refresh token returned from the
-                                   adwords-downloader-refresh-oauth2-token script.
-                                   Default: "ABCDefgh!1234567890ABCDefgh!123456789
-                                   0ABCDefgh!1234567890ABCDefgh!1234567890ABCDefgh
-                                   !1234567890ABCDefgh!1234567890ABCDefgh!12345678
-                                   90"
-      --data_dir TEXT              The directory where result data is written to.
-                                   Default: "/tmp/bingads/"
-      --data_file TEXT             The name of the file the result is written to.
-                                   Default: "ad_performance.csv.gz"
-      --first_date TEXT            The first day from which on data will be
-                                   downloaded. Default: "2015-01-01"
-      --environment TEXT           The deployment environment. Default:
-                                   "production"
-      --timeout TEXT               The maximum amount of time (in milliseconds)
-                                   that you want to wait for the report download.
-                                   Default: "3600000"
-      --help                       Show this message and exit.
+
+      --developer_token TEXT          The developer token that is used to access
+                                      the BingAds API. Default: "012345679ABCDEF"
+      --oauth2_client_id TEXT         The Oauth client id obtained from the
+                                      BingAds developer center. Default:
+                                      "abc1234-1234-1234-abc-abcd1234"
+      --oauth2_client_secret TEXT     The Oauth client secret obtained from the
+                                      BingAds developer center. Default:
+                                      "ABCDefgh!1234567890"
+      --oauth2_refresh_token TEXT     The Oauth refresh token returned from the
+                                      adwords-downloader-refresh-oauth2-token
+                                      script. Default: "ABCDefgh!1234567890ABCDefg
+                                      h!1234567890ABCDefgh!1234567890ABCDefgh!1234
+                                      567890ABCDefgh!1234567890ABCDefgh!1234567890
+                                      ABCDefgh!1234567890"
+      --data_dir TEXT                 The directory where result data is written
+                                      to. Default: "/tmp/bingads/"
+      --data_file TEXT                The name of the file the result is written
+                                      to. Default: "ad_performance.csv.gz"
+      --first_date TEXT               The first day from which on data will be
+                                      downloaded. Default: "2015-01-01"
+      --environment TEXT              The deployment environment. Default:
+                                      "production"
+      --timeout INTEGER               The maximum amount of time (in milliseconds)
+                                      that you want to wait for the report
+                                      download. Default: "3600000"
+      --total_attempts_for_single_file INTEGER
+                                      The attempts to download a single file in
+                                      case of HTTP errors or timeouts. Default:
+                                      "5"
+      --retry_timeout_interval INTEGER
+                                      number of seconds to wait before trying
+                                      again to download a single day. Default:
+                                      "10"
+      --help                          Show this message and exit.
+

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # BingAds Performance Downloader
 
 A Python script for downloading performance data from the [BingAds API version 11](https://msdn.microsoft.com/en-us/library/bing-ads-overview(v=msads.100).aspx) to local files. The code is largely based on [Bing Ads Python SDK](https://github.com/BingAds/BingAds-Python-SDK).
- 
+
 
 ## Resulting data
 **BingAds Performance Downloader** gives measures such as impressions, clicks and cost. The script creates one csv file per day in a specified time range:
 
     /tmp/bingads/2016/05/02/bing/ad_performance.csv.gz
     /tmp/bingads/2016/05/03/bing/ad_performance.csv.gz
-    
-    
+
+
  Each line contains one ad for one day:
- 
+
     GregorianDate        | 2/12/2016
     AccountId            | 17837800573
     AccountName          | Online Veiling Gent
@@ -33,17 +33,17 @@ A Python script for downloading performance data from the [BingAds API version 1
     Conversions          | 0
     Revenue              | 0
     Network              | Bing and Yahoo! search
-    
+
 
 ## Getting Started
 
-  
+
 ### Installation
 
  The Bing AdWords Performance Downloader requires:
 
     Python (>= 3.5)
-    bingads (>=10.4.11)
+    bingads (==11.5.5.1)
     click (>=6.0)
 
 The easiest way to install bing-adwords-downloader is using pip
@@ -61,14 +61,14 @@ If you want to install it in a virtual environment:
 
 Getting access to the Bing Ads Account:
 
-Ask your SEM manager to invite you to the Bing Ads Account of the company. The role should be Super Admin. Once you receive the confirmation e-mail 
-(may take up to 2 hours), you should click on the link and create a Microsoft account. 
+Ask your SEM manager to invite you to the Bing Ads Account of the company. The role should be Super Admin. Once you receive the confirmation e-mail
+(may take up to 2 hours), you should click on the link and create a Microsoft account.
 
 Getting **developer token**:
 Go to this page https://developers.bingads.microsoft.com/Account, you will find your developer-token. You have to be logged in with your Microsoft account.
 
 Getting **oauth client id** and **oauth client secret** :
-Go to this page https://apps.dev.microsoft.com/. You have to be logged in with your Microsoft account. Set a **Native-Application** and allow **built-in redirect URIs**. 
+Go to this page https://apps.dev.microsoft.com/. You have to be logged in with your Microsoft account. Set a **Native-Application** and allow **built-in redirect URIs**.
 
 ![](docs/Register-App-for-BingAds.png)
 
@@ -84,14 +84,14 @@ In order to access the BingAds API you have to obtain the OAuth2 credentials fro
     $ refresh-bingsads-api-oauth2-token \
     --developer_token ABCDEFEGHIJKL \
     --oauth2_client_id 123456789 \
-    --oauth2_client_secret aBcDeFg 
+    --oauth2_client_secret aBcDeFg
 
 This will open a webbrowser to allow the OAuth2 credentials to access the API on your behalf.  
 ![](docs/oauth1.png)
 ![](docs/oauth2.png)
 
-**Copy the url from the browser** as instructed in the commandline. Paste it into the command line where you are running 
-`refresh-bingsads-api-oauth2-token` and press enter. 
+**Copy the url from the browser** as instructed in the commandline. Paste it into the command line where you are running
+`refresh-bingsads-api-oauth2-token` and press enter.
 
 
 The script should complete and display an offline **refresh token** on the command line. Keep this refresh token for the download step.
@@ -107,38 +107,48 @@ To run the BingAds Performance Downloader call `download-bingsads-performance-da
     --oauth2_refresh_token MCQL58pByMOdq*sU7 \
     --data_dir /tmp/bingads
 
-For all options, see 
+For all options, see
 
     $ download-bingsads-performance-data --help
     Usage: download-bingsads-performance-data [OPTIONS]
-    
+
       Downloads data. When options are not specified, then the defaults from
       config.py are used.
-    
+
     Options:
-      --developer_token TEXT       The developer token that is used to access the
-                                   BingAds API. Default: "012345679ABCDEF"
-      --oauth2_client_id TEXT      The Oauth client id obtained from the BingAds
-                                   developer center. Default:
-                                   "abc1234-1234-1234-abc-abcd1234"
-      --oauth2_client_secret TEXT  The Oauth client secret obtained from the
-                                   BingAds developer center. Default:
-                                   "ABCDefgh!1234567890"
-      --oauth2_refresh_token TEXT  The Oauth refresh token returned from the
-                                   adwords-downloader-refresh-oauth2-token script.
-                                   Default: "ABCDefgh!1234567890ABCDefgh!123456789
-                                   0ABCDefgh!1234567890ABCDefgh!1234567890ABCDefgh
-                                   !1234567890ABCDefgh!1234567890ABCDefgh!12345678
-                                   90"
-      --data_dir TEXT              The directory where result data is written to.
-                                   Default: "/tmp/bingads/"
-      --data_file TEXT             The name of the file the result is written to.
-                                   Default: "ad_performance.csv.gz"
-      --first_date TEXT            The first day from which on data will be
-                                   downloaded. Default: "2015-01-01"
-      --environment TEXT           The deployment environment. Default:
-                                   "production"
-      --timeout TEXT               The maximum amount of time (in milliseconds)
-                                   that you want to wait for the report download.
-                                   Default: "3600000"
-      --help                       Show this message and exit.
+
+      --developer_token TEXT          The developer token that is used to access
+                                      the BingAds API. Default: "012345679ABCDEF"
+      --oauth2_client_id TEXT         The Oauth client id obtained from the
+                                      BingAds developer center. Default:
+                                      "abc1234-1234-1234-abc-abcd1234"
+      --oauth2_client_secret TEXT     The Oauth client secret obtained from the
+                                      BingAds developer center. Default:
+                                      "ABCDefgh!1234567890"
+      --oauth2_refresh_token TEXT     The Oauth refresh token returned from the
+                                      adwords-downloader-refresh-oauth2-token
+                                      script. Default: "ABCDefgh!1234567890ABCDefg
+                                      h!1234567890ABCDefgh!1234567890ABCDefgh!1234
+                                      567890ABCDefgh!1234567890ABCDefgh!1234567890
+                                      ABCDefgh!1234567890"
+      --data_dir TEXT                 The directory where result data is written
+                                      to. Default: "/tmp/bingads/"
+      --data_file TEXT                The name of the file the result is written
+                                      to. Default: "ad_performance.csv.gz"
+      --first_date TEXT               The first day from which on data will be
+                                      downloaded. Default: "2015-01-01"
+      --environment TEXT              The deployment environment. Default:
+                                      "production"
+      --timeout INTEGER               The maximum amount of time (in milliseconds)
+                                      that you want to wait for the report
+                                      download. Default: "3600000"
+      --total_attempts_for_single_file INTEGER
+                                      The attempts to download a single file in
+                                      case of HTTP errors or timeouts. Default:
+                                      "5"
+      --retry_timeout_interval INTEGER
+                                      number of seconds to wait before trying
+                                      again to download a single day. Default:
+                                      "10"
+      --help                          Show this message and exit.
+

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # BingAds Performance Downloader
 
 A Python script for downloading performance data from the [BingAds API version 11](https://msdn.microsoft.com/en-us/library/bing-ads-overview(v=msads.100).aspx) to local files. The code is largely based on [Bing Ads Python SDK](https://github.com/BingAds/BingAds-Python-SDK).
- 
+
 
 ## Resulting data
 **BingAds Performance Downloader** gives measures such as impressions, clicks and cost. The script creates one csv file per day in a specified time range:
 
     /tmp/bingads/2016/05/02/bing/ad_performance.csv.gz
     /tmp/bingads/2016/05/03/bing/ad_performance.csv.gz
-    
-    
+
+
  Each line contains one ad for one day:
- 
+
     GregorianDate        | 2/12/2016
     AccountId            | 17837800573
     AccountName          | Online Veiling Gent
@@ -33,17 +33,17 @@ A Python script for downloading performance data from the [BingAds API version 1
     Conversions          | 0
     Revenue              | 0
     Network              | Bing and Yahoo! search
-    
+
 
 ## Getting Started
 
-  
+
 ### Installation
 
  The Bing AdWords Performance Downloader requires:
 
     Python (>= 3.5)
-    bingads (>=10.4.11)
+    bingads (==11.5.5.1)
     click (>=6.0)
 
 The easiest way to install bing-adwords-downloader is using pip
@@ -61,14 +61,14 @@ If you want to install it in a virtual environment:
 
 Getting access to the Bing Ads Account:
 
-Ask your SEM manager to invite you to the Bing Ads Account of the company. The role should be Super Admin. Once you receive the confirmation e-mail 
-(may take up to 2 hours), you should click on the link and create a Microsoft account. 
+Ask your SEM manager to invite you to the Bing Ads Account of the company. The role should be Super Admin. Once you receive the confirmation e-mail
+(may take up to 2 hours), you should click on the link and create a Microsoft account.
 
 Getting **developer token**:
 Go to this page https://developers.bingads.microsoft.com/Account, you will find your developer-token. You have to be logged in with your Microsoft account.
 
 Getting **oauth client id** and **oauth client secret** :
-Go to this page https://apps.dev.microsoft.com/. You have to be logged in with your Microsoft account. Set a **Native-Application** and allow **built-in redirect URIs**. 
+Go to this page https://apps.dev.microsoft.com/. You have to be logged in with your Microsoft account. Set a **Native-Application** and allow **built-in redirect URIs**.
 
 ![](docs/Register-App-for-BingAds.png)
 
@@ -84,14 +84,14 @@ In order to access the BingAds API you have to obtain the OAuth2 credentials fro
     $ refresh-bingsads-api-oauth2-token \
     --developer_token ABCDEFEGHIJKL \
     --oauth2_client_id 123456789 \
-    --oauth2_client_secret aBcDeFg 
+    --oauth2_client_secret aBcDeFg
 
 This will open a webbrowser to allow the OAuth2 credentials to access the API on your behalf.  
 ![](docs/oauth1.png)
 ![](docs/oauth2.png)
 
-**Copy the url from the browser** as instructed in the commandline. Paste it into the command line where you are running 
-`refresh-bingsads-api-oauth2-token` and press enter. 
+**Copy the url from the browser** as instructed in the commandline. Paste it into the command line where you are running
+`refresh-bingsads-api-oauth2-token` and press enter.
 
 
 The script should complete and display an offline **refresh token** on the command line. Keep this refresh token for the download step.
@@ -107,14 +107,14 @@ To run the BingAds Performance Downloader call `download-bingsads-performance-da
     --oauth2_refresh_token MCQL58pByMOdq*sU7 \
     --data_dir /tmp/bingads
 
-For all options, see 
+For all options, see
 
     $ download-bingsads-performance-data --help
     Usage: download-bingsads-performance-data [OPTIONS]
-    
+
       Downloads data. When options are not specified, then the defaults from
       config.py are used.
-    
+
     Options:
       --developer_token TEXT       The developer token that is used to access the
                                    BingAds API. Default: "012345679ABCDEF"

--- a/bingads_downloader/cli.py
+++ b/bingads_downloader/cli.py
@@ -1,5 +1,7 @@
 """Command line interface for adwords downloader"""
 
+import sys
+
 import click
 from bingads_downloader import downloader,config
 from functools import partial
@@ -20,6 +22,16 @@ def apply_options(kwargs):
         if value: setattr(config, key, partial(lambda v: v, value))
 
 
+def show_version():
+    """Shows the package version in logs, if possible"""
+    try:
+        import pkg_resources
+        version = pkg_resources.require("bingads-performance-downloader")[0].version
+        print('Bing ads performance downloader version {}'.format(version))
+    except:
+        print('Warning: cannot determine module version')
+        print(sys.exc_info())
+
 @click.command()
 @config_option(config.developer_token)
 @config_option(config.oauth2_client_id)
@@ -29,6 +41,7 @@ def refresh_oauth2_token(**kwargs):
     Creates a new OAuth2 token.
     When options are not specified, then the defaults from config.py are used.
     """
+    show_version()
     apply_options(kwargs)
     downloader.refresh_oauth_token()
 
@@ -48,5 +61,6 @@ def download_data(**kwargs):
     Downloads data.
     When options are not specified, then the defaults from config.py are used.
     """
+    show_version()
     apply_options(kwargs)
     downloader.download_data()

--- a/bingads_downloader/cli.py
+++ b/bingads_downloader/cli.py
@@ -1,23 +1,35 @@
 """Command line interface for adwords downloader"""
 
+import sys
+
 import click
 from bingads_downloader import downloader,config
 from functools import partial
 
 
-def config_option(config_function):
+def config_option(config_function, default_value = None):
     """Helper decorator that turns an option function into a cli option"""
-
     return lambda function: \
         click.option('--' + config_function.__name__,
-                     help=f'{config_function.__doc__}. Default: "{config_function()}"') \
-            (function)
+                     help=f'{config_function.__doc__}. Default: "{config_function()}"',
+                     default=default_value)(function)
 
 
 def apply_options(kwargs):
     """Applies passed cli parameters to config.py"""
     for key, value in kwargs.items():
         if value: setattr(config, key, partial(lambda v: v, value))
+
+
+def show_version():
+    """Shows the package version in logs, if possible"""
+    try:
+        import pkg_resources
+        version = pkg_resources.require("bingads-performance-downloader")[0].version
+        print('Bing ads performance downloader version {}'.format(version))
+    except:
+        print('Warning: cannot determine module version')
+        print(sys.exc_info())
 
 
 @click.command()
@@ -30,6 +42,7 @@ def refresh_oauth2_token(**kwargs):
     When options are not specified, then the defaults from config.py are used.
     """
     apply_options(kwargs)
+    show_version()
     downloader.refresh_oauth_token()
 
 
@@ -43,10 +56,13 @@ def refresh_oauth2_token(**kwargs):
 @config_option(config.first_date)
 @config_option(config.environment)
 @config_option(config.timeout)
+@config_option(config.total_attempts_for_single_file)
+@config_option(config.retry_timeout_interval)
 def download_data(**kwargs):
     """
     Downloads data.
     When options are not specified, then the defaults from config.py are used.
     """
     apply_options(kwargs)
+    show_version()
     downloader.download_data()

--- a/bingads_downloader/cli.py
+++ b/bingads_downloader/cli.py
@@ -32,6 +32,7 @@ def show_version():
         print('Warning: cannot determine module version')
         print(sys.exc_info())
 
+
 @click.command()
 @config_option(config.developer_token)
 @config_option(config.oauth2_client_id)
@@ -41,8 +42,8 @@ def refresh_oauth2_token(**kwargs):
     Creates a new OAuth2 token.
     When options are not specified, then the defaults from config.py are used.
     """
-    show_version()
     apply_options(kwargs)
+    show_version()
     downloader.refresh_oauth_token()
 
 
@@ -63,6 +64,6 @@ def download_data(**kwargs):
     Downloads data.
     When options are not specified, then the defaults from config.py are used.
     """
-    show_version()
     apply_options(kwargs)
+    show_version()
     downloader.download_data()

--- a/bingads_downloader/cli.py
+++ b/bingads_downloader/cli.py
@@ -56,6 +56,8 @@ def refresh_oauth2_token(**kwargs):
 @config_option(config.first_date)
 @config_option(config.environment)
 @config_option(config.timeout)
+@config_option(config.total_attempts_for_single_file)
+@config_option(config.retry_timeout_interval)
 def download_data(**kwargs):
     """
     Downloads data.

--- a/bingads_downloader/cli.py
+++ b/bingads_downloader/cli.py
@@ -7,12 +7,11 @@ from bingads_downloader import downloader,config
 from functools import partial
 
 
-def config_option(config_function, default_value = None):
+def config_option(config_function):
     """Helper decorator that turns an option function into a cli option"""
     return lambda function: \
         click.option('--' + config_function.__name__,
-                     help=f'{config_function.__doc__}. Default: "{config_function()}"',
-                     default=default_value)(function)
+                     help=f'{config_function.__doc__}. Default: "{config_function()}"')(function)
 
 
 def apply_options(kwargs):

--- a/bingads_downloader/cli.py
+++ b/bingads_downloader/cli.py
@@ -12,8 +12,8 @@ def config_option(config_function):
 
     return lambda function: \
         click.option('--' + config_function.__name__,
-                     help=f'{config_function.__doc__}. Default: "{config_function()}"') \
-            (function)
+                     help=f'{config_function.__doc__}. Default: "{config_function()}"',
+                     default=config_function())(function)
 
 
 def apply_options(kwargs):

--- a/bingads_downloader/cli.py
+++ b/bingads_downloader/cli.py
@@ -7,13 +7,12 @@ from bingads_downloader import downloader,config
 from functools import partial
 
 
-def config_option(config_function):
+def config_option(config_function, default_value = None):
     """Helper decorator that turns an option function into a cli option"""
-
     return lambda function: \
         click.option('--' + config_function.__name__,
                      help=f'{config_function.__doc__}. Default: "{config_function()}"',
-                     default=config_function())(function)
+                     default=default_value)(function)
 
 
 def apply_options(kwargs):

--- a/bingads_downloader/config.py
+++ b/bingads_downloader/config.py
@@ -45,3 +45,12 @@ def oauth2_refresh_token() -> str:
 def timeout() -> int:
     """The maximum amount of time (in milliseconds) that you want to wait for the report download"""
     return 3600000
+
+
+def total_attempts_for_single_file() -> int:
+    """The attempts to donwload a single file in case of HTTP errors or timeouts"""
+    return 5
+
+def retry_timeout_interval() -> int:
+    """number of seconds to wait before trying again to download a single day"""
+    return 10

--- a/bingads_downloader/config.py
+++ b/bingads_downloader/config.py
@@ -45,3 +45,13 @@ def oauth2_refresh_token() -> str:
 def timeout() -> int:
     """The maximum amount of time (in milliseconds) that you want to wait for the report download"""
     return 3600000
+
+
+def total_attempts_for_single_file() -> int:
+    """The attempts to download a single file in case of HTTP errors or timeouts"""
+    return 5
+
+
+def retry_timeout_interval() -> int:
+    """number of seconds to wait before trying again to download a single day"""
+    return 10

--- a/bingads_downloader/config.py
+++ b/bingads_downloader/config.py
@@ -48,8 +48,9 @@ def timeout() -> int:
 
 
 def total_attempts_for_single_file() -> int:
-    """The attempts to donwload a single file in case of HTTP errors or timeouts"""
+    """The attempts to download a single file in case of HTTP errors or timeouts"""
     return 5
+
 
 def retry_timeout_interval() -> int:
     """number of seconds to wait before trying again to download a single day"""

--- a/bingads_downloader/downloader.py
+++ b/bingads_downloader/downloader.py
@@ -75,9 +75,10 @@ def download_ad_performance_data(api_client: BingReportClient):
                 try:
                     start_time = time.time()
                     submit_and_download(report_request, api_client, str(filepath))
-                    print('Downloaded data for {date:%Y-%m-%d} in {elapsed:.1f} seconds'
+                    print('Successfully downloaded data for {date:%Y-%m-%d} in {elapsed:.1f} seconds'
                           .format(date=current_date, elapsed=time.time() - start_time))
-                    current_date += datetime.timedelta(days=-1)
+                    # date is decreased only if the download above does not fail
+                    current_date -= datetime.timedelta(days=1)
                     remaining_attempts = config.total_attempts_for_single_file
                 except urllib.error.URLError as url_error:
                     if remaining_attempts == 0:

--- a/bingads_downloader/downloader.py
+++ b/bingads_downloader/downloader.py
@@ -75,7 +75,7 @@ def download_ad_performance_data(api_client: BingReportClient):
                 try:
                     start_time = time.time()
                     submit_and_download(report_request, api_client, str(filepath))
-                    print('Downloaded {date:%Y-%m-%d} in {elapsed} seconds'
+                    print('Downloaded data for {date:%Y-%m-%d} in {elapsed:.1f} seconds'
                           .format(date=current_date, elapsed=time.time() - start_time))
                     current_date += datetime.timedelta(days=-1)
                     remaining_attempts = config.total_attempts_for_single_file
@@ -83,7 +83,7 @@ def download_ad_performance_data(api_client: BingReportClient):
                     if remaining_attempts == 0:
                         print('Too many failed attempts while downloading this day, quitting', file=sys.stderr)
                         raise
-                    print('ERROR IN DOWNLOADING REPORT, RETRYING in {} seconds, attempt {}#...'
+                    print('ERROR WHILE DOWNLOADING REPORT, RETRYING in {} seconds, attempt {}#...'
                           .format(config.retry_timeout_interval, remaining_attempts), file=sys.stderr)
                     print(url_error, file=sys.stderr)
                     time.sleep(config.retry_timeout_interval)

--- a/bingads_downloader/downloader.py
+++ b/bingads_downloader/downloader.py
@@ -73,7 +73,10 @@ def download_ad_performance_data(api_client: BingReportClient):
                 tmp_filepath = Path(tmp_dir, relative_filepath)
                 tmp_filepath.parent.mkdir(exist_ok=True, parents=True)
                 try:
+                    start_time = time.time()
                     submit_and_download(report_request, api_client, str(filepath))
+                    print('Downloaded {date:%Y-%m-%d} in {elapsed} seconds'
+                          .format(date=current_date, elapsed=time.time() - start_time))
                     current_date += datetime.timedelta(days=-1)
                     remaining_attempts = config.total_attempts_for_single_file
                 except urllib.error.URLError as url_error:

--- a/bingads_downloader/downloader.py
+++ b/bingads_downloader/downloader.py
@@ -2,6 +2,7 @@ import datetime
 import errno
 import sys
 import tempfile
+import urllib
 import webbrowser
 from pathlib import Path
 
@@ -59,6 +60,7 @@ def download_ad_performance_data(api_client: BingReportClient):
     first_date = datetime.datetime.strptime(config.first_date(), '%Y-%m-%d')
     last_date = datetime.datetime.now() - datetime.timedelta(days=1)
     current_date = last_date
+    remaining_attempts = config.total_attempts_for_single_file
     while current_date >= first_date:
         print(current_date)
         relative_filepath = Path('{date:%Y/%m/%d}/bing/'.format(
@@ -70,9 +72,19 @@ def download_ad_performance_data(api_client: BingReportClient):
             with tempfile.TemporaryDirectory() as tmp_dir:
                 tmp_filepath = Path(tmp_dir, relative_filepath)
                 tmp_filepath.parent.mkdir(exist_ok=True, parents=True)
-                submit_and_download(report_request, api_client, str(filepath))
-
-        current_date += datetime.timedelta(days=-1)
+                try:
+                    submit_and_download(report_request, api_client, str(filepath))
+                    current_date += datetime.timedelta(days=-1)
+                    remaining_attempts = config.total_attempts_for_single_file
+                except urllib.error.URLError as url_error:
+                    if remaining_attempts == 0:
+                        print('Too many failed attempts while downloading this day, quitting', file=sys.stderr)
+                        raise
+                    print('ERROR IN DOWNLOADING REPORT, RETRYING in {} seconds, attempt {}#...'
+                          .format(config.retry_timeout_interval, remaining_attempts), file=sys.stderr)
+                    print(url_error, file=sys.stderr)
+                    time.sleep(config.retry_timeout_interval)
+                    remaining_attempts -= 1
 
 
 def build_ad_performance_request_for_single_day(api_client: BingReportClient,

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setup(
             'refresh-bingsads-api-oauth2-token=bingads_downloader.cli:refresh_oauth2_token'
         ]
     },
-    python_requires='>=3.3'
+    python_requires='>=3.6'
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     description="Downloads data from the BingAds Api to local files for usage in a data warehouse",
 
     install_requires=[
-        'bingads==11.5.04',
+        'bingads==11.5.5.1',
         'click>=6.0'
     ],
 


### PR DESCRIPTION
Three small changes:

- retry a download in case of HTTP error, the timeout and number of attempts are configurable
- show the version of the package in the log
- show the time spent downloading each single file in the log