### PR TITLE
BingAds Downloader v13 upgrade

### DIFF
--- a/bingads_downloader/config.py
+++ b/bingads_downloader/config.py
@@ -45,6 +45,10 @@ def oauth2_account_id() -> str:
     """The customer ID for the person"""
     return "438958943"
 
+def oauth2_account_array():
+    """ Returns the list of accounts as an array"""
+    return ['435435435','435435435']
+    
 def timeout() -> int:
     """The maximum amount of time (in milliseconds) that you want to wait for the report download"""
     return 3600000

--- a/bingads_downloader/config.py
+++ b/bingads_downloader/config.py
@@ -37,6 +37,13 @@ def oauth2_refresh_token() -> str:
     """The Oauth refresh token returned from the adwords-downloader-refresh-oauth2-token script"""
     return 'ABCDefgh!1234567890ABCDefgh!1234567890ABCDefgh!1234567890ABCDefgh!1234567890ABCDefgh!1234567890ABCDefgh!1234567890ABCDefgh!1234567890'
 
+def oauth2_customer_id() -> str:
+    """The customer ID for the person"""
+    return 438958943
+
+def oauth2_account_id() -> str:
+    """The customer ID for the person"""
+    return 438958943
 
 def timeout() -> int:
     """The maximum amount of time (in milliseconds) that you want to wait for the report download"""

--- a/bingads_downloader/config.py
+++ b/bingads_downloader/config.py
@@ -39,11 +39,11 @@ def oauth2_refresh_token() -> str:
 
 def oauth2_customer_id() -> str:
     """The customer ID for the person"""
-    return 438958943
+    return "438958943"
 
 def oauth2_account_id() -> str:
     """The customer ID for the person"""
-    return 438958943
+    return "438958943"
 
 def timeout() -> int:
     """The maximum amount of time (in milliseconds) that you want to wait for the report download"""

--- a/bingads_downloader/config.py
+++ b/bingads_downloader/config.py
@@ -48,7 +48,7 @@ def oauth2_account_id() -> str:
 def oauth2_account_array():
     """ Returns the list of accounts as an array"""
     return ['435435435','435435435']
-    
+
 def timeout() -> int:
     """The maximum amount of time (in milliseconds) that you want to wait for the report download"""
     return 3600000
@@ -66,4 +66,4 @@ def retry_timeout_interval() -> int:
 
 def output_file_version() -> str:
     """A suffix that is added to output files, denoting a version of the data format"""
-    return 'v4'
+    return 'v3'

--- a/bingads_downloader/downloader.py
+++ b/bingads_downloader/downloader.py
@@ -391,6 +391,11 @@ def build_keyword_performance_request(api_client: BingReportClient,
     report_request.Format = 'Csv'
     report_request.ReportName = 'My Keyword Performance Report'
     report_request.ReturnOnlyCompleteData = False
+    scope = api_client.factory.create('AccountThroughCampaignReportScope')
+    scope.AccountIds={'long': config.oauth2_account_array()}
+    scope.Campaigns=None
+    report_request.Scope=scope
+
     if all_time:
         report_request.Aggregation = 'Yearly'
     else:
@@ -457,6 +462,10 @@ def build_campaign_performance_request(api_client: BingReportClient,
     report_request.Format = 'Csv'
     report_request.ReportName = 'My Campaign Performance Report'
     report_request.ReturnOnlyCompleteData = False
+    scope = api_client.factory.create('AccountThroughCampaignReportScope')
+    scope.AccountIds={'long': config.oauth2_account_array()}
+    scope.Campaigns=None
+    report_request.Scope=scope
     #report_request.Language = 'English'
     if all_time:
         report_request.Aggregation = 'Yearly'

--- a/bingads_downloader/downloader.py
+++ b/bingads_downloader/downloader.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from bingads import (AuthorizationData, OAuthAuthorization, OAuthDesktopMobileAuthCodeGrant,
                      OAuthTokenRequestException)
 from bingads.service_client import ServiceClient
-from bingads.v12.reporting.reporting_service_manager import ReportingServiceManager, time
+from bingads.v13.reporting.reporting_service_manager import ReportingServiceManager, time
 from suds import WebFault
 
 from bingads_downloader import config
@@ -29,13 +29,16 @@ class BingReportClient(ServiceClient):
     def __init__(self):
         authorization_data = AuthorizationData(
             developer_token=config.developer_token(),
+            customer_id=config.oauth2_customer_id(),
+            account_id=config.oauth2_account_id(),
             authentication=OAuthAuthorization(client_id=config.oauth2_client_id(),
-                                              oauth_tokens=config.developer_token()),
+                                              oauth_tokens=config.developer_token()
+                                             ),
         )
 
         self.client = super(BingReportClient, self).__init__(service='ReportingService',
                                                              authorization_data=authorization_data,
-                                                             environment='production', version='v12')
+                                                             environment='production', version='v13')
 
 
 def download_data():
@@ -319,11 +322,15 @@ def build_ad_performance_request(api_client: BingReportClient,
     report_request.Format = 'Csv'
     report_request.ReportName = 'My Ad Performance Report'
     report_request.ReturnOnlyCompleteData = False
+    scope = api_client.factory.create('AccountThroughCampaignReportScope')
+    scope.AccountIds={'long': '' }
+    scope.Campaigns=None
+    report_request.Scope=scope
     if all_time:
         report_request.Aggregation = 'Yearly'
     else:
         report_request.Aggregation = 'Daily'
-    report_request.Language = 'English'
+    #report_request.Language = 'English'
     report_request.Time = set_report_time(api_client, current_date, all_time)
 
     report_columns = api_client.factory.create('ArrayOfAdPerformanceReportColumn')
@@ -388,7 +395,7 @@ def build_keyword_performance_request(api_client: BingReportClient,
         report_request.Aggregation = 'Yearly'
     else:
         report_request.Aggregation = 'Daily'
-    report_request.Language = 'English'
+    #report_request.Language = 'English'
 
     report_request.Time = set_report_time(api_client, current_date, all_time)
 
@@ -450,7 +457,7 @@ def build_campaign_performance_request(api_client: BingReportClient,
     report_request.Format = 'Csv'
     report_request.ReportName = 'My Campaign Performance Report'
     report_request.ReturnOnlyCompleteData = False
-    report_request.Language = 'English'
+    #report_request.Language = 'English'
     if all_time:
         report_request.Aggregation = 'Yearly'
     else:

--- a/bingads_downloader/downloader.py
+++ b/bingads_downloader/downloader.py
@@ -323,7 +323,7 @@ def build_ad_performance_request(api_client: BingReportClient,
     report_request.ReportName = 'My Ad Performance Report'
     report_request.ReturnOnlyCompleteData = False
     scope = api_client.factory.create('AccountThroughCampaignReportScope')
-    scope.AccountIds={'long': '' }
+    scope.AccountIds={'long': config.oauth2_account_array()}
     scope.Campaigns=None
     report_request.Scope=scope
     if all_time:

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ from setuptools import setup, find_packages
 setup(
     name='bingads-performance-downloader',
 
-    version='3.0.0',
+    version='4.0.0',
 
     description="Downloads data from the BingAds Api to local files for usage in a data warehouse",
 
     install_requires=[
-        'bingads==11.12.2',
+        'bingads==13.0.1',
         'click>=6.0'
     ],
 


### PR DESCRIPTION
Changed the API so that it works with BingAds v13.

- Added scope to the report requests so that they can query the Bingads server.
- Removed language from the requests.
- Changed version number to 4.0.0 and the required bingads library to 13.0.1.

The following needs to be added to the setup_app.py file in Mara and a refresh of oauth2 Token needs to be run before running the downloads and updated. 
``` 
patch(bingads_downloader.config.oauth2_customer_id)(lambda: 2435435)
patch(bingads_downloader.config.oauth2_account_id)(lambda: 435435435)
patch(bingads_downloader.config.output_file_version)(lambda: 'v4')
patch(bingads_downloader.config.oauth2_account_array)(lambda: ['43543543','345435']) 
```